### PR TITLE
Add GPX option to website frontend

### DIFF
--- a/touchterrain/server/TouchTerrain_app.py
+++ b/touchterrain/server/TouchTerrain_app.py
@@ -39,6 +39,7 @@ app = Flask(__name__)
 # import modules from common
 from touchterrain.common import TouchTerrainEarthEngine # will also init EE
 from touchterrain.common.Coordinate_system_conv import * # arc to meters conversion
+from touchterrain.common.TouchTerrainGPX import addGPXToModel # import addGPXToModel function
 
 import logging
 import time
@@ -567,6 +568,16 @@ def export():
 
         # set geojson_polygon as polygon arg (None by default)
         args["polygon"] = geojson_polygon
+
+        # handle GPX file upload
+        importedGPX = None
+        if 'gpx_file' in request.files:
+            gpx_file = request.files['gpx_file']
+            if gpx_file.filename != '':
+                gpx_file_path = os.path.join(TMP_FOLDER, gpx_file.filename)
+                gpx_file.save(gpx_file_path)
+                importedGPX = [gpx_file_path]
+                args["importedGPX"] = importedGPX
 
         # show snazzy animated gif - set to style="display: none to hide once processing is done
         html = '<img src="static/processing.gif" id="gif" alt="processing animation" style="display: block;">\n'

--- a/touchterrain/server/templates/index.html
+++ b/touchterrain/server/templates/index.html
@@ -280,6 +280,11 @@
 										<label class="custom-file-label" id="kml_file_name" for="kml_file">Optional Polygon KML file:</label>
 								</div>
                                 <br>
+                                <div class="custom-file">
+                                    <input type="file" class="custom-file-input" id="gpx_file" name="gpx_file">
+                                    <label class="custom-file-label" id="gpx_file_name" for="gpx_file">Optional GPX file:</label>
+                                </div>
+                                <br>
                                 <div class="form-inline">
                                     <div class="form-group " >
                                         <input type="text" class="form-control form-control-sm" id="scale" name="scale" maxlength="12" size="3" value="1.00"
@@ -540,6 +545,7 @@
 						<input type="hidden" name="map_lat" id="map_lat3" value="NULL">
 						<input type="hidden" name="map_lon" id="map_lon3" value="NULL">
 						<input type="hidden" name="map_zoom" id="map_zoom3" value="NULL">
+						<input type="hidden" name="gpx_file_data" id="gpx_file_data" value="NULL">
 
 						<!-- hidden submit so it fires (instead of real submit) when Enter is hit in any text inside the form -->
 						<button type="submit" disabled style="display: none" aria-hidden="true"></button>

--- a/touchterrain/server/templates/touchterrain.js
+++ b/touchterrain/server/templates/touchterrain.js
@@ -1,5 +1,3 @@
-// touchterrain JS
-
 "use strict";  // http://javascript.info/strict-mode
 
 
@@ -10,7 +8,7 @@ let eemap = -1    // Google Earth Engine map
 let div_lines_x = []; // internal division lines for tile boundaries
 let div_lines_y = [];
 let polygon = -1  // optional masking polygon
-
+let gpxPaths = []; // array to store multiple GPX paths
 
 /**
 * This page will be called from a Python script that uses
@@ -48,7 +46,6 @@ let transp = "{{ transp }}";
 let gamma = "{{ gamma }}";
 let hsazi = "{{ hsazi }}";
 let hselev = "{{ hselev }}";
-
 
 // run this once the browser is ready
 window.onload = function () {
@@ -299,6 +296,37 @@ window.onload = function () {
             polygon.setMap(null); // remove any earlier polygon
         }
       } // if (fileInput.files.length)
+    });
+
+    // add change callback for gpx_file button
+    let gpxFileInput = document.getElementById('gpx_file');
+    gpxFileInput.addEventListener('change', function(e) {
+        if (gpxFileInput.files.length) {
+            let file = gpxFileInput.files[0];
+            let reader = new FileReader();
+            reader.onload = function(e) {
+                const gpxData = e.target.result;
+                const parser = new DOMParser();
+                const xmlDoc = parser.parseFromString(gpxData, "application/xml");
+                const coordinates = [];
+                const trkpts = xmlDoc.getElementsByTagName("trkpt");
+                for (let i = 0; i < trkpts.length; i++) {
+                    const lat = parseFloat(trkpts[i].getAttribute("lat"));
+                    const lon = parseFloat(trkpts[i].getAttribute("lon"));
+                    coordinates.push({ lat: lat, lng: lon });
+                }
+                const gpxPath = new google.maps.Polyline({
+                    path: coordinates,
+                    geodesic: true,
+                    strokeColor: "#FF0000",
+                    strokeOpacity: 1.0,
+                    strokeWeight: 2,
+                });
+                gpxPath.setMap(map);
+                gpxPaths.push(gpxPath); // add the new path to the array
+            };
+            reader.readAsText(file);
+        }
     });
 
     // Place Search


### PR DESCRIPTION
Add GPX file upload and display functionality to the website frontend.

* Modify `touchterrain/server/TouchTerrain_app.py` to handle GPX file uploads and process GPX data.
* Modify `touchterrain/server/templates/touchterrain.js` to handle GPX file uploads and display GPX tracks on the map.
* Modify `touchterrain/server/templates/index.html` to include input fields for uploading GPX files and a hidden input field to store GPX file data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bscholer/TouchTerrain_for_CAGEO/pull/1?shareId=a90bc705-0110-4ab1-a96e-90c2fe238fde).